### PR TITLE
Fix race condition on stopping lsp client

### DIFF
--- a/pylspclient/lsp_endpoint.py
+++ b/pylspclient/lsp_endpoint.py
@@ -90,6 +90,9 @@ class LspEndpoint(threading.Thread):
         self.event_dict[current_id] = cond
         cond.acquire()
         self.send_message(method_name, kwargs, current_id)
+        if self.shutdown_flag:
+            return None
+
         cond.wait()
         cond.release()
         result, error = self.response_dict[current_id]


### PR DESCRIPTION
Without this fix, it can cause LSP Client to get stuck randomly at `cond.wait()` since other thread won't release the lock due to shutdown_flag being active.