### PR TITLE
feat: LanguageIdentifier.LEAN

### DIFF
--- a/pylspclient/lsp_pydantic_strcuts.py
+++ b/pylspclient/lsp_pydantic_strcuts.py
@@ -53,6 +53,7 @@ class LanguageIdentifier(str, Enum):
     XML="xml"
     XSL="xsl"
     YAML="yaml"
+    LEAN="lean"
 
 class TextDocumentItem(BaseModel):
     """


### PR DESCRIPTION
I would like to use pylspclient to communicate with the Lean server, so I need to add LanguageIdentifier.LEAN to the LanguageIdentifier enum.